### PR TITLE
client_credentials grant type removed for public client type

### DIFF
--- a/oauth/src/main/java/dynamind/oauth2/Application.java
+++ b/oauth/src/main/java/dynamind/oauth2/Application.java
@@ -156,7 +156,7 @@ public class Application extends SpringBootServletInitializer {
 
                             // Public client where client secret is vulnerable (e.g. mobile apps, browsers)
                     .withClient("public") // No secret!
-                    .authorizedGrantTypes("client_credentials", "implicit")
+                    .authorizedGrantTypes("implicit")
                     .scopes("read")
                     .redirectUris("http://localhost:8080/client/")
 


### PR DESCRIPTION
According to [rfc6749#section-4.4](https://tools.ietf.org/html/rfc6749#section-4.4), we cannot use client_credentials grant type for public client.

> The client credentials grant type MUST only be used by confidential clients.
